### PR TITLE
multivariate plotOutliers and report

### DIFF
--- a/nPYc/Templates/NPC_MultivariateReport.html
+++ b/nPYc/Templates/NPC_MultivariateReport.html
@@ -75,7 +75,7 @@
 {% endif %}
 
 {% if 'Noutliers_total' in item %}
-	<p>Excluding outliers in both scores and DmodX space would result in {{ item['Noutliers_total'] }} exclusions.</p>
+	<p>Excluding outliers (as specified) would result in {{ item['Noutliers_total'] }} exclusions.</p>
 {% endif %}
 
 {% if 'Outliers_total_details' in item %}


### PR DESCRIPTION
Fix Fcrit line in plotOutliers to user specified alpha
Improve plotOutliers (red line at critical value if specified)
Set default criticalVals for multivariateReport outlier flags to None (quantiles and Fcrit will still be plotted, but outliers only listed when criticalVals specified by user)